### PR TITLE
Make it possible to disable dependencies only used by the binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,16 @@ path = "src/lib.rs"
 [[bin]]
 name = "cargo-bundle-licenses"
 path = "src/main.rs"
+required-features = ["binary-dependencies"]
+
+[features]
+default = ["binary-dependencies"]
+binary-dependencies = [ "anyhow", "env_logger", "structopt" ]
 
 [dependencies]
-anyhow = "1.0.43"
+anyhow = {version = "1.0.43", optional = true}
 cargo_metadata = "0.14.0"
-env_logger = "0.9.0"
+env_logger = {version = "0.9.0", optional = true}
 itertools = "0.10.1"
 log = "0.4.14"
 regex = "1.5.4"
@@ -30,7 +35,7 @@ serde = {version = "1.0.130", features = ["derive"]}
 serde_json = "1.0.67"
 serde_yaml = "0.8.20"
 slug = "0.1.4"
-structopt = "0.3.22"
+structopt = {version = "0.3.22", optional = true}
 strum = {version = "0.21.0", features = ["derive"]}
 thiserror = "1.0.27"
 toml = "0.5.8"


### PR DESCRIPTION
Adds a feature required by the binary to enable the dependencies only used by it.
The feature is set as a default feature so it does not need to be specified explicitly when building the binary.
When using the lib one would probably want to disable default features to remove the unnecessary dependencies. 

An alternative would be to spilt the project into two packages one with the library and one with the binary to specify the dependencies independently, though that would require more churn.
