### PR TITLE
Add Unicode-DFS-2016 license

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -38,6 +38,7 @@ pub enum License {
     AGPL_3_0,
     AGPL_3_0Plus,
     Zlib,
+    UnicodeDFS2016,
 
     // Special cases
     Custom(String),
@@ -65,6 +66,7 @@ impl License {
             License::LGPL_2_1Plus => include_str!("licenses/LGPL-2.1-or-later"),
             License::LGPL_3_0Plus => include_str!("licenses/LGPL-3.0-or-later"),
             License::Zlib => include_str!("licenses/Zlib"),
+            License::UnicodeDFS2016 => include_str!("licenses/Unicode-DFS-2016"),
             License::Multiple(_) => unimplemented!(), // This should be impossible to hit
             _ => return None,
         })
@@ -109,6 +111,7 @@ fn simple_license(s: &str) -> License {
         "AGPL-3.0-only" | "AGPL-3.0" => License::AGPL_3_0,
         "AGPL-3.0-or-later" | "AGPL-3.0+" => License::AGPL_3_0Plus,
         "Zlib" => License::Zlib,
+        "Unicode-DFS-2016" => License::UnicodeDFS2016,
         // TODO: Sort out the SPDX "AND"
         s if s.contains('/') || s.contains(" OR ") => {
             let mut licenses = s
@@ -176,6 +179,7 @@ impl fmt::Display for License {
             License::AGPL_3_0 => write!(w, "AGPL-3.0-only"),
             License::AGPL_3_0Plus => write!(w, "AGPL-3.0-or-later"),
             License::Zlib => write!(w, "Zlib"),
+            License::UnicodeDFS2016 => write!(w, "Unicode-DFS-2016"),
             License::Custom(ref s) => write!(w, "{}", s),
             License::File(ref f) => {
                 write!(w, "License specified in file ({})", f.to_string_lossy())
@@ -268,6 +272,10 @@ mod test {
         );
         assert_eq!(License::from_str("AGPL-3.0+"), Ok(License::AGPL_3_0Plus));
         assert_eq!(License::from_str("Zlib"), Ok(License::Zlib));
+        assert_eq!(
+            License::from_str("Unicode-DFS-2016"),
+            Ok(License::UnicodeDFS2016)
+        );
     }
 
     #[test]

--- a/src/licenses/Unicode-DFS-2016
+++ b/src/licenses/Unicode-DFS-2016
@@ -1,0 +1,46 @@
+UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use <https://www.unicode.org/copyright.html>
+for definitions of Unicode Inc.’s Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © <YEAR> <COPYRIGHT HOLDER>. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.


### PR DESCRIPTION
Closes #18.

The license text can be found at https://spdx.org/licenses/Unicode-DFS-2016.html, though the actual plain text version added here was copied from the unicode-ident crate.