### PR TITLE
Move check for license-file outside of read_dir() loop

### DIFF
--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -167,22 +167,22 @@ pub fn find_package_license(
                     confidence,
                 });
             }
-        } else if let Some(rel_path) = package.license_file() {
-            // Lastly try the specified license file which may work better for workspaces
-            if let Ok(text) = fs::read_to_string(&rel_path) {
-                let confidence = check_against_template(&text, license);
-                generic = Some(LicenseText {
-                    path: rel_path.into_std_path_buf(),
-                    text,
-                    confidence,
-                });
-            }
         }
     }
 
     if texts.is_empty() {
         if let Some(generic) = generic {
             texts.push(generic);
+        } else if let Some(rel_path) = package.license_file() {
+            // Lastly try the specified license file which may work better for workspaces
+            if let Ok(text) = fs::read_to_string(&rel_path) {
+                let confidence = check_against_template(&text, license);
+                texts.push(LicenseText {
+                    path: rel_path.into_std_path_buf(),
+                    text,
+                    confidence,
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Currently, `find_package_license()` checks whether a package has a `license-file` on every iteration through its `read_dir()` loop, but only if the current file doesn't have a recognized license name.  Because the order in which `read_dir()` returns its values is filesystem-dependent (and may as well be non-deterministic), this can lead to situations like `generic` being set to the `license-file` and then later being reset to a generic license file if that happens to be the last file yielded.  Presumably, what you want to happen is for `generic` to be set to the `license-file` if no generic license is found in the whole directory, which is what this PR accomplishes.