### PR TITLE
detect LICENSE-UNICODE file for Unicode-dfs-2016 in crate unicode-ident

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -214,6 +214,10 @@ impl License {
                 slugify(self.to_string()).to_lowercase(),
                 String::from("boost"),
             ],
+            License::UnicodeDFS2016 => vec![
+                slugify(self.to_string()).to_lowercase(),
+                String::from("unicode"),
+            ],
             _ => vec![slugify(self.to_string()).to_lowercase()],
         };
         synonyms.sort_by_key(|value| -(value.len() as i64));


### PR DESCRIPTION
Detect LICENSE-UNICODE file as UNICODE-DFS-2016 for a popular crate [unicode-ident](https://crates.io/crates/unicode-ident/1.0.12)