### PR TITLE
Add Unicode-3.0 license

### DIFF
--- a/src/license.rs
+++ b/src/license.rs
@@ -38,6 +38,7 @@ pub enum License {
     AGPL_3_0,
     AGPL_3_0Plus,
     Zlib,
+    Unicode_3_0,
     UnicodeDFS2016,
     ISC,
 
@@ -67,6 +68,7 @@ impl License {
             License::LGPL_2_1Plus => include_str!("licenses/LGPL-2.1-or-later"),
             License::LGPL_3_0Plus => include_str!("licenses/LGPL-3.0-or-later"),
             License::Zlib => include_str!("licenses/Zlib"),
+            License::Unicode_3_0 => include_str!("licenses/Unicode-3.0"),
             License::UnicodeDFS2016 => include_str!("licenses/Unicode-DFS-2016"),
             License::ISC => include_str!("licenses/ISC"),
             License::MPL_2_0 => include_str!("licenses/MPL-2.0"),
@@ -114,6 +116,7 @@ fn simple_license(s: &str) -> License {
         "AGPL-3.0-only" | "AGPL-3.0" => License::AGPL_3_0,
         "AGPL-3.0-or-later" | "AGPL-3.0+" => License::AGPL_3_0Plus,
         "Zlib" => License::Zlib,
+        "Unicode-3.0" => License::Unicode_3_0,
         "Unicode-DFS-2016" => License::UnicodeDFS2016,
         "ISC" => License::ISC,
         // TODO: Sort out the SPDX "AND"
@@ -183,6 +186,7 @@ impl fmt::Display for License {
             License::AGPL_3_0 => write!(w, "AGPL-3.0-only"),
             License::AGPL_3_0Plus => write!(w, "AGPL-3.0-or-later"),
             License::Zlib => write!(w, "Zlib"),
+            License::Unicode_3_0 => write!(w, "Unicode-3.0"),
             License::UnicodeDFS2016 => write!(w, "Unicode-DFS-2016"),
             License::ISC => write!(w, "ISC"),
             License::Custom(ref s) => write!(w, "{}", s),
@@ -215,7 +219,7 @@ impl License {
                 slugify(self.to_string()).to_lowercase(),
                 String::from("boost"),
             ],
-            License::UnicodeDFS2016 => vec![
+            License::Unicode_3_0 | License::UnicodeDFS2016 => vec![
                 slugify(self.to_string()).to_lowercase(),
                 String::from("unicode"),
             ],
@@ -281,6 +285,7 @@ mod test {
         );
         assert_eq!(License::from_str("AGPL-3.0+"), Ok(License::AGPL_3_0Plus));
         assert_eq!(License::from_str("Zlib"), Ok(License::Zlib));
+        assert_eq!(License::from_str("Unicode-3.0"), Ok(License::Unicode_3_0));
         assert_eq!(
             License::from_str("Unicode-DFS-2016"),
             Ok(License::UnicodeDFS2016)

--- a/src/licenses/Unicode-3.0
+++ b/src/licenses/Unicode-3.0
@@ -1,0 +1,39 @@
+UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © <YEAR> <COPYRIGHT HOLDER>
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the "Data Files") or
+software and any associated documentation (the "Software") to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.


### PR DESCRIPTION
The `unicode-ident` library replaced its `Unicode-DFS-2016` license with `Unicode-3.0` [last week](https://github.com/dtolnay/unicode-ident/commit/36cccb825aef6f334cfb57afc82a728c3d2d652f).  This PR makes `cargo-bundle-licenses` recognize the new license.