### PR TITLE
feat: allow passing non-default features

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,10 @@ pub struct Opts {
     /// After filling in not-found licenses, check if new is a strict subset of previous.
     #[structopt(long, short)]
     check_previous: bool,
+
+    /// A list of additional features to pull dependencies from (default features are always enabled)
+    #[structopt(long, short, use_delimiter = true, empty_values = false)]
+    features: Vec<String>,
 }
 
 /// Parse args and set up logging / tracing
@@ -92,7 +96,13 @@ fn main() -> Result<()> {
         None
     };
 
-    let bundle = BundleBuilder::exec_with_previous(previous.as_ref())?;
+    let mut bundle_builder = BundleBuilder::new().features(&opts.features);
+
+    if let Some(previous) = previous.as_ref() {
+        bundle_builder = bundle_builder.previous(previous);
+    }
+
+    let bundle = bundle_builder.exec()?;
 
     let output = get_output(opts.output)?;
 

--- a/src/package_loader.rs
+++ b/src/package_loader.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashSet, VecDeque};
 
 use cargo_metadata::{
-    DependencyKind, Metadata, MetadataCommand, NodeDep, Package, PackageId, Resolve,
+    CargoOpt, DependencyKind, Metadata, MetadataCommand, NodeDep, Package, PackageId, Resolve,
 };
 use thiserror::Error;
 
@@ -26,9 +26,12 @@ pub struct PackageLoader {
 }
 
 impl PackageLoader {
-    /// Create a new package loader that loads teh cargo metadata
-    pub fn new() -> Result<Self, PackageLoaderError> {
-        let metadata = MetadataCommand::new().exec()?;
+    /// Create a new package loader that loads the cargo metadata
+    pub fn new(features: &[String]) -> Result<Self, PackageLoaderError> {
+        let metadata = MetadataCommand::new()
+            .features(CargoOpt::SomeFeatures(features.to_vec()))
+            .exec()?;
+
         Ok(Self { metadata })
     }
 


### PR DESCRIPTION
This PR allows for passing additional features for the package (either space or comma-separated, multiple occurrences of `--features [...]` are allowed). This allows us to pull licenses for optional dependencies. Notice that the default features are always enabled.

If at least one non-existing feature is provided, the CLI will exit with an error message:
```
cargo bundle-licenses --features somefeature,nonexistent --output THIRDPARTY.toml
Error: `cargo metadata` exited with an error: error: the package 'package' does not contain this feature: nonexistent
```
Similarly, passing empty feature list will error out as well:
```
cargo bundle-licenses --features --output THIRDPARTY.toml
error: The argument '--features <features>...' requires a value but none was supplied

USAGE:
    cargo bundle-licenses --features <features>... --format <format> --output <output>

For more information try --help
```
(I guess this is desirable behavior to catch interpolating empty values in scripts etc.)

While this isn't a breaking change for the CLI itself (default features are preserved and the new option is, well, optional), this is a breaking change for the `cargo-bundle-licenses` as a library. If this is an issue, we can consider preserving the old API and creating separate methods / structs that the old API will proxy to.

Fixes #47 