### PR TITLE
make Bundle fields accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.2.0
+
+- [feature](https://github.com/sstadick/cargo-bundle-licenses/pull/56): add accessors for the fields of `Bundle`
+
 # v4.1.0
 
 - [chore](https://github.com/sstadick/cargo-bundle-licenses/pull/55): update deps to remove transitive dependency on `syn@1`

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -162,6 +162,14 @@ impl Bundle {
         }
     }
 
+    pub fn root_name(&self) -> &str {
+        &self.root_name
+    }
+
+    pub fn third_party_libraries(&self) -> &[FinalizedLicense] {
+        &self.third_party_libraries
+    }
+
     /// Compare another [`Bundle`] against this [`Bundle`] requiring that "other" be a strict subset of self.
     pub fn check_subset(&self, other: &Self) -> bool {
         if self.root_name != other.root_name {


### PR DESCRIPTION
This allows programmatic access to parsed/generated bundles. This access can then be used to more easily generate output in other formats such as the human-readable format requested in sstadick/cargo-bundle-licenses#39 without having to have the support integrated into cargo-bundle-licenses

Alternatively rather than making the fields public getters could be added instead.